### PR TITLE
Fix CLI --provider option to respect provider selection

### DIFF
--- a/packages/import/src/blockchains/avalanche/transaction-importer.ts
+++ b/packages/import/src/blockchains/avalanche/transaction-importer.ts
@@ -21,7 +21,7 @@ export type AvalancheRawTransactionData = SnowtraceTransaction | SnowtraceIntern
 export class AvalancheTransactionImporter extends BaseImporter<AvalancheRawTransactionData> {
   private providerManager: BlockchainProviderManager;
 
-  constructor(dependencies: IDependencyContainer) {
+  constructor(dependencies: IDependencyContainer, options?: { preferredProvider?: string | undefined }) {
     super('avalanche');
 
     if (!dependencies.providerManager || !dependencies.explorerConfig) {
@@ -31,7 +31,7 @@ export class AvalancheTransactionImporter extends BaseImporter<AvalancheRawTrans
     this.providerManager = dependencies.providerManager;
 
     // Auto-register providers for avalanche mainnet
-    this.providerManager.autoRegisterFromConfig('avalanche', 'mainnet');
+    this.providerManager.autoRegisterFromConfig('avalanche', 'mainnet', options?.preferredProvider);
 
     this.logger.info(
       `Initialized Avalanche transaction importer - ProvidersCount: ${this.providerManager.getProviders('avalanche').length}`

--- a/packages/import/src/blockchains/bitcoin/transaction-importer.ts
+++ b/packages/import/src/blockchains/bitcoin/transaction-importer.ts
@@ -21,7 +21,10 @@ export class BitcoinTransactionImporter extends BaseImporter<BitcoinTransaction>
   private providerManager: BlockchainProviderManager;
   private walletAddresses: BitcoinWalletAddress[] = [];
 
-  constructor(dependencies: IDependencyContainer, options?: { addressGap?: number }) {
+  constructor(
+    dependencies: IDependencyContainer,
+    options?: { addressGap?: number; preferredProvider?: string | undefined }
+  ) {
     super('bitcoin');
 
     if (!dependencies.providerManager || !dependencies.explorerConfig) {
@@ -32,7 +35,7 @@ export class BitcoinTransactionImporter extends BaseImporter<BitcoinTransaction>
     this.addressGap = options?.addressGap || 20;
 
     // Auto-register providers for bitcoin mainnet
-    this.providerManager.autoRegisterFromConfig('bitcoin', 'mainnet');
+    this.providerManager.autoRegisterFromConfig('bitcoin', 'mainnet', options?.preferredProvider);
 
     this.logger.info(
       `Initialized Bitcoin transaction importer - AddressGap: ${this.addressGap}, ProvidersCount: ${this.providerManager.getProviders('bitcoin').length}`

--- a/packages/import/src/blockchains/ethereum/transaction-importer.ts
+++ b/packages/import/src/blockchains/ethereum/transaction-importer.ts
@@ -22,7 +22,7 @@ export type EthereumRawTransactionData = AlchemyAssetTransfer | MoralisTransacti
 export class EthereumTransactionImporter extends BaseImporter<EthereumRawTransactionData> {
   private providerManager: BlockchainProviderManager;
 
-  constructor(dependencies: IDependencyContainer) {
+  constructor(dependencies: IDependencyContainer, options?: { preferredProvider?: string | undefined }) {
     super('ethereum');
 
     if (!dependencies.providerManager || !dependencies.explorerConfig) {
@@ -32,7 +32,7 @@ export class EthereumTransactionImporter extends BaseImporter<EthereumRawTransac
     this.providerManager = dependencies.providerManager;
 
     // Auto-register providers for ethereum mainnet
-    this.providerManager.autoRegisterFromConfig('ethereum', 'mainnet');
+    this.providerManager.autoRegisterFromConfig('ethereum', 'mainnet', options?.preferredProvider);
 
     this.logger.info(
       `Initialized Ethereum transaction importer - ProvidersCount: ${this.providerManager.getProviders('ethereum').length}`

--- a/packages/import/src/blockchains/injective/transaction-importer.ts
+++ b/packages/import/src/blockchains/injective/transaction-importer.ts
@@ -14,7 +14,7 @@ import type { InjectiveTransaction } from './types.ts';
 export class InjectiveTransactionImporter extends BaseImporter<InjectiveTransaction> {
   private providerManager: BlockchainProviderManager;
 
-  constructor(dependencies: IDependencyContainer) {
+  constructor(dependencies: IDependencyContainer, options?: { preferredProvider?: string | undefined }) {
     super('injective');
 
     if (!dependencies.providerManager || !dependencies.explorerConfig) {
@@ -24,7 +24,7 @@ export class InjectiveTransactionImporter extends BaseImporter<InjectiveTransact
     this.providerManager = dependencies.providerManager;
 
     // Auto-register providers for injective mainnet
-    this.providerManager.autoRegisterFromConfig('injective', 'mainnet');
+    this.providerManager.autoRegisterFromConfig('injective', 'mainnet', options?.preferredProvider);
 
     this.logger.info(
       `Initialized Injective transaction importer - ProvidersCount: ${this.providerManager.getProviders('injective').length}`

--- a/packages/import/src/blockchains/polkadot/bittensor-transaction-importer.ts
+++ b/packages/import/src/blockchains/polkadot/bittensor-transaction-importer.ts
@@ -14,7 +14,7 @@ import type { TaostatsTransaction } from './types.ts';
 export class BittensorTransactionImporter extends BaseImporter<TaostatsTransaction> {
   private providerManager: BlockchainProviderManager;
 
-  constructor(dependencies: IDependencyContainer) {
+  constructor(dependencies: IDependencyContainer, options?: { preferredProvider?: string | undefined }) {
     super('bittensor');
 
     if (!dependencies.providerManager || !dependencies.explorerConfig) {
@@ -24,7 +24,7 @@ export class BittensorTransactionImporter extends BaseImporter<TaostatsTransacti
     this.providerManager = dependencies.providerManager;
 
     // Auto-register providers for bittensor mainnet
-    this.providerManager.autoRegisterFromConfig('bittensor', 'mainnet');
+    this.providerManager.autoRegisterFromConfig('bittensor', 'mainnet', options?.preferredProvider);
 
     this.logger.info(
       `Initialized Bittensor transaction importer - ProvidersCount: ${this.providerManager.getProviders('bittensor').length}`

--- a/packages/import/src/blockchains/polkadot/transaction-importer.ts
+++ b/packages/import/src/blockchains/polkadot/transaction-importer.ts
@@ -14,7 +14,7 @@ import type { SubscanTransfer } from './types.ts';
 export class PolkadotTransactionImporter extends BaseImporter<SubscanTransfer> {
   private providerManager: BlockchainProviderManager;
 
-  constructor(dependencies: IDependencyContainer) {
+  constructor(dependencies: IDependencyContainer, options?: { preferredProvider?: string | undefined }) {
     super('polkadot');
 
     if (!dependencies.providerManager || !dependencies.explorerConfig) {
@@ -24,7 +24,7 @@ export class PolkadotTransactionImporter extends BaseImporter<SubscanTransfer> {
     this.providerManager = dependencies.providerManager;
 
     // Auto-register providers for polkadot mainnet
-    this.providerManager.autoRegisterFromConfig('polkadot', 'mainnet');
+    this.providerManager.autoRegisterFromConfig('polkadot', 'mainnet', options?.preferredProvider);
 
     this.logger.info(
       `Initialized Polkadot transaction importer - ProvidersCount: ${this.providerManager.getProviders('polkadot').length}`

--- a/packages/import/src/blockchains/solana/transaction-importer.ts
+++ b/packages/import/src/blockchains/solana/transaction-importer.ts
@@ -16,7 +16,7 @@ import { isValidSolanaAddress } from './utils.ts';
 export class SolanaTransactionImporter extends BaseImporter<SolanaRawTransactionData> {
   private providerManager: BlockchainProviderManager;
 
-  constructor(dependencies: IDependencyContainer) {
+  constructor(dependencies: IDependencyContainer, options?: { preferredProvider?: string | undefined }) {
     super('solana');
 
     if (!dependencies.providerManager || !dependencies.explorerConfig) {
@@ -26,7 +26,7 @@ export class SolanaTransactionImporter extends BaseImporter<SolanaRawTransaction
     this.providerManager = dependencies.providerManager;
 
     // Auto-register providers for solana mainnet
-    this.providerManager.autoRegisterFromConfig('solana', 'mainnet');
+    this.providerManager.autoRegisterFromConfig('solana', 'mainnet', options?.preferredProvider);
 
     this.logger.info(
       `Initialized Solana transaction importer - ProvidersCount: ${this.providerManager.getProviders('solana').length}`

--- a/packages/import/src/shared/common/interfaces.ts
+++ b/packages/import/src/shared/common/interfaces.ts
@@ -24,6 +24,7 @@ export interface IDependencyContainer {
  */
 export interface ETLComponentConfig {
   dependencies: IDependencyContainer;
+  providerId?: string | undefined;
   sessionMetadata?: unknown;
   sourceId: string;
   sourceType: 'exchange' | 'blockchain';

--- a/packages/import/src/shared/importers/importer-factory.ts
+++ b/packages/import/src/shared/importers/importer-factory.ts
@@ -35,7 +35,9 @@ export class ImporterFactory {
   private static async createAvalancheImporter<T>(config: ETLComponentConfig): Promise<IImporter<T>> {
     // Dynamic import to avoid circular dependencies
     const { AvalancheTransactionImporter } = await import('../../blockchains/avalanche/transaction-importer.ts');
-    return new AvalancheTransactionImporter(config.dependencies) as unknown as IImporter<T>;
+    return new AvalancheTransactionImporter(config.dependencies, {
+      preferredProvider: config.providerId,
+    }) as unknown as IImporter<T>;
   }
 
   /**
@@ -44,7 +46,9 @@ export class ImporterFactory {
   private static async createBitcoinImporter<T>(config: ETLComponentConfig): Promise<IImporter<T>> {
     // Dynamic import to avoid circular dependencies
     const { BitcoinTransactionImporter } = await import('../../blockchains/bitcoin/transaction-importer.ts');
-    return new BitcoinTransactionImporter(config.dependencies) as unknown as IImporter<T>;
+    return new BitcoinTransactionImporter(config.dependencies, {
+      preferredProvider: config.providerId,
+    }) as unknown as IImporter<T>;
   }
 
   /**
@@ -55,7 +59,9 @@ export class ImporterFactory {
     const { BittensorTransactionImporter } = await import(
       '../../blockchains/polkadot/bittensor-transaction-importer.ts'
     );
-    return new BittensorTransactionImporter(config.dependencies) as unknown as IImporter<T>;
+    return new BittensorTransactionImporter(config.dependencies, {
+      preferredProvider: config.providerId,
+    }) as unknown as IImporter<T>;
   }
 
   /**
@@ -110,7 +116,9 @@ export class ImporterFactory {
   private static async createEthereumImporter<T>(config: ETLComponentConfig): Promise<IImporter<T>> {
     // Dynamic import to avoid circular dependencies
     const { EthereumTransactionImporter } = await import('../../blockchains/ethereum/transaction-importer.ts');
-    return new EthereumTransactionImporter(config.dependencies) as unknown as IImporter<T>;
+    return new EthereumTransactionImporter(config.dependencies, {
+      preferredProvider: config.providerId,
+    }) as unknown as IImporter<T>;
   }
 
   /**
@@ -144,7 +152,9 @@ export class ImporterFactory {
   private static async createInjectiveImporter<T>(config: ETLComponentConfig): Promise<IImporter<T>> {
     // Dynamic import to avoid circular dependencies
     const { InjectiveTransactionImporter } = await import('../../blockchains/injective/transaction-importer.ts');
-    return new InjectiveTransactionImporter(config.dependencies) as unknown as IImporter<T>;
+    return new InjectiveTransactionImporter(config.dependencies, {
+      preferredProvider: config.providerId,
+    }) as unknown as IImporter<T>;
   }
 
   /**
@@ -180,7 +190,9 @@ export class ImporterFactory {
   private static async createPolkadotImporter<T>(config: ETLComponentConfig): Promise<IImporter<T>> {
     // Dynamic import to avoid circular dependencies
     const { PolkadotTransactionImporter } = await import('../../blockchains/polkadot/transaction-importer.ts');
-    return new PolkadotTransactionImporter(config.dependencies) as unknown as IImporter<T>;
+    return new PolkadotTransactionImporter(config.dependencies, {
+      preferredProvider: config.providerId,
+    }) as unknown as IImporter<T>;
   }
 
   /**
@@ -189,7 +201,9 @@ export class ImporterFactory {
   private static async createSolanaImporter<T>(config: ETLComponentConfig): Promise<IImporter<T>> {
     // Dynamic import to avoid circular dependencies
     const { SolanaTransactionImporter } = await import('../../blockchains/solana/transaction-importer.ts');
-    return new SolanaTransactionImporter(config.dependencies) as unknown as IImporter<T>;
+    return new SolanaTransactionImporter(config.dependencies, {
+      preferredProvider: config.providerId,
+    }) as unknown as IImporter<T>;
   }
 
   /**

--- a/packages/import/src/shared/ingestion/ingestion-service.ts
+++ b/packages/import/src/shared/ingestion/ingestion-service.ts
@@ -151,6 +151,7 @@ export class TransactionIngestionService {
       // Create importer
       const importer = await ImporterFactory.create({
         dependencies: this.dependencies,
+        providerId: params.providerId,
         sourceId: sourceId,
         sourceType: sourceType,
       });


### PR DESCRIPTION
## Summary

Fixes the `--provider` CLI option which was being ignored by blockchain importers. The option now properly filters to the specified provider and exits with a clear error if the provider is not available.

## Problem

The `--provider` option was passed through the ingestion service but never used by blockchain importers. The `BlockchainProviderManager` was auto-registering all enabled providers from config and using its own failover logic, completely ignoring the user's provider preference.

## Solution

1. **Modified BlockchainProviderManager.autoRegisterFromConfig()**: Added optional `preferredProvider` parameter that filters to only the specified provider
2. **Updated data flow**: 
   - Added `providerId` to `ETLComponentConfig` interface  
   - Modified ingestion service to pass `providerId` to importer factory
   - Updated all blockchain importers to accept and use `preferredProvider` option
3. **Error handling**: Now throws clear error when specified provider is not found instead of logging warning and continuing

## Changes Made

- Modified `BlockchainProviderManager.autoRegisterFromConfig()` to accept and filter by preferred provider
- Updated `ETLComponentConfig` interface to include `providerId`
- Modified `TransactionIngestionService` to pass provider ID to importers  
- Updated all blockchain transaction importers (Bitcoin, Ethereum, Solana, Avalanche, Injective, Polkadot, Bittensor) to accept `preferredProvider` option
- Changed error handling to exit immediately when invalid provider specified

## Testing

### Before
```bash
pnpm run import -- --blockchain bitcoin --provider tatum --addresses <address>
# Would log warning and use other providers anyway
```

### After  
```bash
pnpm run import -- --blockchain bitcoin --provider tatum --addresses <address>
# Now exits with clear error: Preferred provider 'tatum' not found or not enabled for bitcoin. Available providers: blockcypher, mempool.space

pnpm run import -- --blockchain bitcoin --provider mempool.space --addresses <address>  
# Now only uses mempool.space provider as intended
```

## Related Issues

- Creates issue #33 documenting type safety concerns with `as unknown` casting (separate from this functional fix)

## Files Changed

- `packages/import/src/blockchains/shared/blockchain-provider-manager.ts`
- `packages/import/src/shared/common/interfaces.ts`
- `packages/import/src/shared/ingestion/ingestion-service.ts`
- `packages/import/src/shared/importers/importer-factory.ts`
- All blockchain transaction importers in `packages/import/src/blockchains/*/transaction-importer.ts`